### PR TITLE
Update error message in cpu_utils.hpp

### DIFF
--- a/cpu_utils.hpp
+++ b/cpu_utils.hpp
@@ -538,7 +538,7 @@ int readSequenceFAST5Files(char **filenames, int num_files, T ***sequences, char
 
                 size_t num_seqs_this_file = read_fast5_data<T>(filenames[i], (*sequences) + actual_count, (*sequence_names) + actual_count, (*sequence_lengths) + actual_count);
                 if(num_seqs_this_file < 1){
-                        std::cerr << "Error reading in FAST5 file " << filenames[i] << ", skipping" << std::endl;
+                        std::cerr << "No reads in FAST5 file " << filenames[i] << ", skipping" << std::endl;
                 }
                 else{
                         actual_count += num_seqs_this_file;


### PR DESCRIPTION
Updated an error message to indicate no reads were found in the FAST5 file rather than just "Error".